### PR TITLE
build-arg-support: Suporte a --build-arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 build/
 bin/
 pkg/
+
+src/github.com/docopt/
+src/github.com/goamz/
+src/github.com/vaughan0/
+src/gopkg.in/
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Harbor takes a YAML configuration file with the following structure.
      permission: <[optional] file permissions, default 0644>
  commands:
    - <YAML array containing shell commands (currently /bin/bash) to be run before 'docker build'>
+ buildargs:
+   <KEY>:<VALUE pair to be used as --build-arg KEY=VALUE>
 ```
 
 You can use `${<KEY>}` as a placeholder in harbor.yml to be replaced by the value passed in a -e flag

--- a/src/github.com/elo7/harbor/config/config.go
+++ b/src/github.com/elo7/harbor/config/config.go
@@ -32,6 +32,7 @@ type HarborConfig struct {
 	ProjectPath  string `yaml:",omitempty"`
 	Files        []HarborFile
 	Commands     []string
+	BuildArgs    map[string]string
 }
 
 func Load(cliConfigVars commandline.ConfigVarsMap, projectPath string, configFile string) (HarborConfig, error) {

--- a/src/github.com/elo7/harbor/execute/docker/docker.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker.go
@@ -62,7 +62,7 @@ func createTimeBasedVersion(t time.Time) string {
 }
 
 func createTag(fromTag string, toTag string) error {
-	if err := runDockerCommand("tag", "-f", fromTag, toTag); err != nil {
+	if err := runDockerCommand("tag", fromTag, toTag); err != nil {
 		return err
 	}
 

--- a/src/github.com/elo7/harbor/execute/docker/docker.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Build(harborConfig config.HarborConfig) error {
-
+	var arguments []string
 	tags := harborConfig.Tags
 
 	if len(tags) == 0 {
@@ -21,8 +21,17 @@ func Build(harborConfig config.HarborConfig) error {
 	}
 
 	imageWithTagsList := createImageWithTagsList(harborConfig.ImageTag, tags)
+	arguments = append(arguments, "build", "-t", imageWithTagsList[0])
+	buildArgs := harborConfig.BuildArgs
 
-	if err := runDockerCommand("build", "-t", imageWithTagsList[0], harborConfig.ProjectPath); err != nil {
+	if len(buildArgs) > 0 {
+		for name, value := range buildArgs {
+			arguments = append(arguments, "--build-arg", name + "=" + value)
+		}
+	}
+
+	arguments = append(arguments, harborConfig.ProjectPath)
+	if err := runDockerCommand(arguments...); err != nil {
 		return err
 	}
 

--- a/src/github.com/elo7/harbor/main.go
+++ b/src/github.com/elo7/harbor/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 )
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.2"
 
 func main() {
 	usage := `Harbor, a Docker wrapper
@@ -32,6 +32,8 @@ Harbor takes a YAML configuration file with the following structure.
      permission: <[optional] file permissions, default 0644>
  commands:
    - <YAML array containing shell commands (currently /bin/bash) to be run before 'docker build'>
+ buildargs:
+   <KEY>:<VALUE pair to be used as --build-arg KEY=VALUE>
 
  You can use ${<KEY>} as a placeholder in harbor.yml to be replaced by the value passed in a -e flag
 


### PR DESCRIPTION
👍  @edsonmarquezani @lucasvasconcelos 
@gmcoringa
## Changelog
- Adicionado suporte a `--build-arg`
- Removida flag `-f` na criação de tags, flag estava deprecada
## Testing
- [ ] habor deve configurar a flag `--build-arg KEY=VALUE` quando o mesmo for configurado no `harbor.yml`
- [ ] SEM a existencia de build arguments no `harbor.yml` o harbor NÃO deve adicionar a flag `--build-arg`

Sample yml:

``` yml
imagetag: registry.docker.elo7aws.com.br/test
buildargs:
  KEY: VALUE
```

Sample Dockerfile:

```
FROM ubuntu

ARG KEY
```
