### PR TITLE
[EM-11982] - [harbor] Detectar versão do docker rodando e adicionar -f na hora de tagear caso DOCKER_VERSION < 1.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ pkg/
 src/github.com/docopt/
 src/github.com/goamz/
 src/github.com/vaughan0/
+src/github.com/hashicorp/
 src/gopkg.in/
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can use `${<KEY>}` as a placeholder in harbor.yml to be replaced by the valu
 ```
 cd harbor
 export GOPATH=$(pwd)
-cd harbor/src/github.com/elo7/harbor
+cd src/github.com/elo7/harbor
 ```
 - Set _GOOS_ and _GOARCH_ variables according to your [plataform](https://golang.org/doc/install/source#environment) and run the following command
 ```

--- a/src/github.com/elo7/harbor/.gitignore
+++ b/src/github.com/elo7/harbor/.gitignore
@@ -1,3 +1,2 @@
 harbor.yml
 Dockerfile
-config/

--- a/src/github.com/elo7/harbor/.gitignore
+++ b/src/github.com/elo7/harbor/.gitignore
@@ -1,2 +1,0 @@
-harbor.yml
-Dockerfile

--- a/src/github.com/elo7/harbor/execute/docker/docker.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker.go
@@ -26,7 +26,7 @@ func Build(harborConfig config.HarborConfig) error {
 
 	if len(buildArgs) > 0 {
 		for name, value := range buildArgs {
-			arguments = append(arguments, "--build-arg", name + "=" + value)
+			arguments = append(arguments, "--build-arg", name+"="+value)
 		}
 	}
 
@@ -71,7 +71,15 @@ func createTimeBasedVersion(t time.Time) string {
 }
 
 func createTag(fromTag string, toTag string) error {
-	if err := runDockerCommand("tag", fromTag, toTag); err != nil {
+	var arguments []string
+
+	if CompareDockerVersion("1.10.0") {
+		arguments = append(arguments, "tag", fromTag, toTag)
+	} else {
+		arguments = append(arguments, "tag", "-f", fromTag, toTag)
+	}
+
+	if err := runDockerCommand(arguments...); err != nil {
 		return err
 	}
 

--- a/src/github.com/elo7/harbor/execute/docker/docker_version.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker_version.go
@@ -1,30 +1,20 @@
 package docker
 
 import (
-	"fmt"
 	"github.com/hashicorp/go-version"
-	"os"
 	"os/exec"
 	"strings"
 )
 
-func GetDockerVersion(dockerVersion *string) {
-
+func GetDockerVersion() (dockerVersion string, err error) {
 	output, err := exec.Command("docker", "version", "--format='{{.Client.Version}}'").CombinedOutput()
-
-	if err != nil {
-		fmt.Println("Não consegui executar o comando 'docker'. Output: " + string(output))
-		os.Exit(1)
-	} else {
-		*dockerVersion = strings.TrimSpace(string(output))
-	}
+	return strings.TrimSpace(string(output)), err
 }
 
 // Retorna false se o docker for menor que a versão passada
 // Returna true se o docker for maior ou igual que a versão passada
 func CompareDockerVersion(dockerCmpVersion string) bool {
-	var dockerVersion string
-	GetDockerVersion(&dockerVersion)
+	dockerVersion, _ := GetDockerVersion()
 	v1, _ := version.NewVersion(dockerVersion)
 	v2, _ := version.NewVersion(dockerCmpVersion)
 

--- a/src/github.com/elo7/harbor/execute/docker/docker_version.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker_version.go
@@ -1,0 +1,36 @@
+package docker
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-version"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func GetDockerVersion(dockerVersion *string) {
+
+	output, err := exec.Command("docker", "version", "--format='{{.Client.Version}}'").CombinedOutput()
+
+	if err != nil {
+		fmt.Println("Não consegui executar o comando 'docker'. Output: " + string(output))
+		os.Exit(1)
+	} else {
+		*dockerVersion = strings.TrimSpace(string(output))
+	}
+}
+
+// Retorna false se o docker for menor que a versão passada
+// Returna true se o docker for maior ou igual que a versão passada
+func CompareDockerVersion(dockerCmpVersion string) bool {
+	var dockerVersion string
+	GetDockerVersion(&dockerVersion)
+	v1, _ := version.NewVersion(dockerVersion)
+	v2, _ := version.NewVersion(dockerCmpVersion)
+
+	if v1.LessThan(v2) {
+		return false
+	} else {
+		return true
+	}
+}

--- a/src/github.com/elo7/harbor/main.go
+++ b/src/github.com/elo7/harbor/main.go
@@ -112,6 +112,12 @@ Options:
 	}
 
 	if !noDockerFlag {
+
+		// Caso docker não existir ou estiver mal-configurado, falho aqui
+		var dockerVersion string
+		docker.GetDockerVersion(&dockerVersion)
+		fmt.Printf("Your Docker client version: %s\n", dockerVersion)
+
 		err = docker.Build(harborConfig)
 		checkError(err)
 	}

--- a/src/github.com/elo7/harbor/main.go
+++ b/src/github.com/elo7/harbor/main.go
@@ -114,9 +114,12 @@ Options:
 	if !noDockerFlag {
 
 		// Caso docker não existir ou estiver mal-configurado, falho aqui
-		var dockerVersion string
-		docker.GetDockerVersion(&dockerVersion)
-		fmt.Printf("Your Docker client version: %s\n", dockerVersion)
+		if dockerVersion, err := docker.GetDockerVersion(); err != nil {
+			fmt.Printf("There was a problem running the docker version command.\n")
+			os.Exit(1)
+		} else {
+			fmt.Printf("Your Docker client version: %s\n", dockerVersion)
+		}
 
 		err = docker.Build(harborConfig)
 		checkError(err)


### PR DESCRIPTION
👍 @rsaraiva
:eyes: @edsonmarquezani @rsaraiva 
:hammer: @lucasvasconcelos

---
# Changelog
- Checagem de versão do Docker client;
- Caso o Docker client não exista ou esteja mal-configurado, o harbor vai jogar um erro (caso o docker seja utilizado);
- Adição do '-f' na hora de criar a tag, caso docker-version < 1.10.0
# Task state
1. [X] Desenvolvido
2. [ ] Testes de unidade criados
3. [X] Testado manualmente por quem criou o PR
4. [x] Aprovado na revisão
5. [x] Testado manualmente pelo revisor
# Tests
## Teste manual:
- Pode-se testar cada novo método de maneira unitária;
- Executar o harbor com --no-docker-push

https://elo7ole.atlassian.net/browse/EM-11982
