### PR TITLE
[bug - BTW-158] - in some scenarios docker does not ignore the single quotes, outputing them and causing the bug

### DIFF
--- a/src/github.com/elo7/harbor/execute/docker/docker_version.go
+++ b/src/github.com/elo7/harbor/execute/docker/docker_version.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetDockerVersion() (dockerVersion string, err error) {
-	output, err := exec.Command("docker", "version", "--format='{{.Client.Version}}'").CombinedOutput()
+	output, err := exec.Command("docker", "version", "--format={{.Client.Version}}").CombinedOutput()
 	return strings.TrimSpace(string(output)), err
 }
 


### PR DESCRIPTION
Removing single quotes from the `docker version` command.
- Tested on OSX and Ubuntu
